### PR TITLE
add coupon fields from other plugins

### DIFF
--- a/includes/admin/wccg-core-functions.php
+++ b/includes/admin/wccg-core-functions.php
@@ -89,6 +89,14 @@ function wccg_generate_coupons( $number, $args = array() ) {
 		'minimum_amount'             => wc_format_decimal( $args['minimum_amount'] ),
 		'maximum_amount'             => wc_format_decimal( $args['maximum_amount'] ),
 		'customer_email'             => array_filter( array_map( 'trim', explode( ',', wc_clean( $args['customer_email'] ) ) ) ),
+		// WooCommerce Subscriptions and other fields
+		'_wcs_number_payments'       => empty( $args['wcs_number_payments'] ) ? '' : absint( $args['wcs_number_payments'] ),
+		'_wc_url_coupons_redirect_page' => empty( $args['_wc_url_coupons_redirect_page'] ) ? '' : absint( explode('|',$args['_wc_url_coupons_redirect_page'] )[1]),
+		'_wc_url_coupons_redirect_page_type' => empty( $args['_wc_url_coupons_redirect_page_type'] ) ? '' : wc_clean( $args['_wc_url_coupons_redirect_page_type'] ),
+		'_wc_url_coupons_product_ids' => isset( $args['_wc_url_coupons_product_ids'] ) ? array_map( 'intval', $args['_wc_url_coupons_product_ids'] ) : array(),
+		'_wc_url_coupons_defer_apply' => isset( $args['_wc_url_coupons_defer_apply'] ) ? 'yes' : 'no',
+		// _wc_url_coupons_unique_url - appending the generated coupon code to the user input so it is unique
+		'_wc_url_coupons_unique_url'  => empty( $args['_wc_url_coupons_unique_url'] ) ? '' : wc_clean( $args['_wc_url_coupons_unique_url'] ) . '-' . sanitize_title( $coupon_code ),
 	), $coupon_id );
 
 


### PR DESCRIPTION
WooCommerce Subscriptions and some other fields were not being passed through to generated coupons.