### PR TITLE
Add options array/filter to customize

### DIFF
--- a/includes/admin/wccg-core-functions.php
+++ b/includes/admin/wccg-core-functions.php
@@ -26,6 +26,17 @@ function wccg_generate_coupons( $number, $args = array() ) {
 
 	// TODO default args
 
+	// Coupon Generation Parameters
+	$options = apply_filters( 'woocommerce-coupon-generator-options-filter',
+		array( 'length' => 12,
+			'charset' => 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
+			'separator' => '-',
+			'segment-size' => 4,
+			'prefix' => '',
+			'postfix' => '',
+		)
+	);
+
 	global $wpdb;
 	$insert_coupon_ids = array();
 
@@ -35,7 +46,7 @@ function wccg_generate_coupons( $number, $args = array() ) {
 	$number_of_coupons = absint( $number );
 	for ( $i = 0; $i < $number_of_coupons; $i++ ) {
 
-		$coupon_code = wccg_get_random_coupon();
+		$coupon_code = wccg_get_random_coupon( $options );
 
 		// Insert coupon post
 		$wpdb->query( $wpdb->prepare( "INSERT INTO $wpdb->posts SET
@@ -128,15 +139,19 @@ function wccg_get_random_coupon() {
 
 	// Generate unique coupon code
 	$random_coupon = '';
-	$length        = 12;
-	$charset       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	$length        = $options['length'];
+	$charset       = $options['charset'];
+	$separator     = $options['separator'];
+	$segment_size  = $options['segment_size'];
+	$prefix        = $options['prefix'];
+	$postfix       = $options['postfix'];
 	$count         = strlen( $charset );
 
 	while ( $length-- ) {
 		$random_coupon .= $charset[ mt_rand( 0, $count-1 ) ];
 	}
 
-	$random_coupon = implode( '-', str_split( strtoupper( $random_coupon ), 4 ) );
+	$random_coupon = $prefix . implode( '-', str_split( strtoupper( $random_coupon ), $segment_size ) ) . $postfix;
 
 	// Ensure coupon code is correctly formatted
 	$coupon_code = apply_filters( 'woocommerce_coupon_code', $random_coupon );


### PR DESCRIPTION
Allow users to customize how the coupon code is generated through a filter with an array of options.

function my_coupon_generation_options_filter( $options ) {
    $options['length'] = 32;
    $options['charset'] = 'CFHMNPRSTWXY347';
    $options['segment_size'] = 8;
    return $options;
}
add_filter('woocommerce-coupon-generator-options-filter', 'my_coupon_generation_options_filter', 10, 1);